### PR TITLE
Moved to Jedis 4.3.0 release (was snapshot).

### DIFF
--- a/src/java/jedis_example/pom.xml
+++ b/src/java/jedis_example/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
-      <version>4.3.0-SNAPSHOT</version>
+      <version>4.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
This moves the Jedis example to use 4.3.0 release (previously used 4.3.0 snapshot).

Closes #5 