### PR TITLE
Adds transcripts README closes #50

### DIFF
--- a/courseware/transcripts/README.md
+++ b/courseware/transcripts/README.md
@@ -1,0 +1,10 @@
+# RU204: Storing, Querying and Indexing JSON at Speed: Transcripts
+
+This folder contains the video transcripts used for the RU204: Storing, Querying and Indexing JSON at Speed course from Redis University.  These are in [subrip format](https://en.wikipedia.org/wiki/SubRip).
+
+* [Sign up for the course here](https://university.redis.com/courses/ru204/).
+* If you spot errors, or feel you can improve the materials, please [open an issue](https://github.com/redislabs-training/ru205/issues) or [submit a pull request](https://github.com/redislabs-training/ru204/pulls).
+
+Thanks,
+
+The Redis University team.


### PR DESCRIPTION
Adds the missing `README.md` in the `courseware/transcripts` folder. Closes #50 